### PR TITLE
added form operand descriptors for replica, expose3scale. replace dep…

### DIFF
--- a/deploy/courier/0.0.1/teiid.0.0.1.clusterserviceversion.yaml
+++ b/deploy/courier/0.0.1/teiid.0.0.1.clusterserviceversion.yaml
@@ -120,17 +120,30 @@ spec:
       - kind: ImageStream
         version: image.openshift.io/v1
       specDescriptors:
-      - description: Runtime
-        displayName: Runtime
-        path: runtime
+      - description: Type
+        displayName: Type
+        path: runtime.type
         x-descriptors:
-        - "urn:alm:descriptor:com.tectonic.ui:label"
+        - "urn:alm:descriptor:com.tectonic.ui:fieldGroup:Runtime"
+        - "urn:alm:descriptor:com.tectonic.ui:text"
+      - description: Version
+        displayName: Version
+        path: runtime.version
+        x-descriptors:
+        - "urn:alm:descriptor:com.tectonic.ui:fieldGroup:Runtime"
+        - "urn:alm:descriptor:com.tectonic.ui:text"
+      - description: Expose Via 3 Scale
+        displayName: Expose Via 3 Scale
+        path: exposeVia3scale
+        value: false
+        x-descriptors:
+        - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+      - description:  Desired number of Pods for the cluster
+        displayName: Size
+        path: replicas
+        x-descriptors:
+        - "urn:alm:descriptor:com.tectonic.ui:podCount"
       statusDescriptors:
-      - description: Deployments for the VirtualDatabase environment.
-        displayName: Deployments
-        path: deployments
-        x-descriptors:
-        - "urn:alm:descriptor:com.tectonic.ui:podStatuses"
       - description: The address for accessing teiid service, if it is deployed.
         displayName: Route
         path: route

--- a/deploy/crds/virtualdatabase.crd.yaml
+++ b/deploy/crds/virtualdatabase.crd.yaml
@@ -56,7 +56,7 @@ spec:
               type: integer
               format: int32
             exposeVia3scale:
-              type: bool
+              type: boolean
             build:
               type: object
               properties:


### PR DESCRIPTION
* Current:-
<img width="1680" alt="Screenshot 2019-10-10 at 2 27 59 PM" src="https://user-images.githubusercontent.com/1783060/66558563-616ee480-eb71-11e9-945d-62195177dbec.png">

* After clicking on "create" button, status page show this error:
<img width="1211" alt="Screenshot 2019-10-10 at 2 25 26 PM" src="https://user-images.githubusercontent.com/1783060/66559084-61bbaf80-eb72-11e9-9226-2b9b97f3da76.png">


* Removed `deployment` from `statusDescriptors`:
<img width="675" alt="Screenshot 2019-10-10 at 2 53 56 PM" src="https://user-images.githubusercontent.com/1783060/66558890-02f63600-eb72-11e9-86eb-6fc9a94b9a23.png">

Added 
* `Expose Via 3 Scale` 
* `Replicas` 

Updated Runtime to use text with field groups, `urn:alm:descriptor:com.tectonic.ui:label` is deprecated

<img width="1385" alt="Screenshot 2019-10-10 at 3 28 31 PM" src="https://user-images.githubusercontent.com/1783060/66559250-ae9f8600-eb72-11e9-9e15-8a5cfe41680f.png">

example: 
<img width="1680" alt="Screenshot 2019-10-10 at 3 01 52 PM" src="https://user-images.githubusercontent.com/1783060/66559613-4d2be700-eb73-11e9-95b5-abee063fef32.png">

